### PR TITLE
Fix enrollment grade update and wording

### DIFF
--- a/src/main/java/org/pangea/sis/controller/StudentController.java
+++ b/src/main/java/org/pangea/sis/controller/StudentController.java
@@ -106,6 +106,6 @@ public class StudentController {
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteStudent(@PathVariable Long id){
         studentService.deleteStudent(id);
-        return new ResponseEntity<>("Player deleted.", HttpStatus.OK);
+        return new ResponseEntity<>("Student deleted.", HttpStatus.OK);
     }
 }

--- a/src/main/java/org/pangea/sis/service/EnrollmentService.java
+++ b/src/main/java/org/pangea/sis/service/EnrollmentService.java
@@ -83,6 +83,7 @@ public class EnrollmentService {
         Enrollment enrollment = enrollmentRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Enrollment not found"));
         enrollment.setGrade(grade);
+        enrollmentRepository.save(enrollment);
         return EnrollmentMapper.toDTO(enrollment);
     }
 

--- a/src/test/java/org/pangea/sis/service/EnrollmentServiceTest.java
+++ b/src/test/java/org/pangea/sis/service/EnrollmentServiceTest.java
@@ -101,6 +101,7 @@ class EnrollmentServiceTest {
         enrollment.setId(enrollmentId);
         enrollment.setGrade(70);
         when(enrollmentRepository.findById(enrollmentId)).thenReturn(Optional.of(enrollment));
+        when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
         EnrollmentDTO dto = enrollmentService.updateGrade(enrollmentId, newGrade);
@@ -109,6 +110,7 @@ class EnrollmentServiceTest {
         assertEquals(newGrade, dto.getGrade());
         assertEquals(enrollmentId, dto.getId());
         verify(enrollmentRepository).findById(enrollmentId);
+        verify(enrollmentRepository).save(enrollment);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- persist enrollment grade updates
- verify save action in tests
- correct deletion message in `StudentController`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490a3d067c83268ea2462561a1b5fa